### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ecellproject/eb8529cf-0484-4300-8e4e-4cf43884e8bf/19867f1f-3841-4ed2-ad07-ff6c8ac45b63/_apis/work/boardbadge/6000450b-2c5e-4243-a4f3-180ad8b5da37)](https://dev.azure.com/ecellproject/eb8529cf-0484-4300-8e4e-4cf43884e8bf/_boards/board/t/19867f1f-3841-4ed2-ad07-ff6c8ac45b63/Microsoft.RequirementCategory)
 E-Cell System version 4
 =======================
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ecellproject/eb8529cf-0484-4300-8e4e-4cf43884e8bf/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.