### PR TITLE
:checkered_flag: prevent macro definitions

### DIFF
--- a/ecell4/core/config.h.in
+++ b/ecell4/core/config.h.in
@@ -27,4 +27,19 @@
 #cmakedefine HAVE_CHRONO 1
 #endif
 
+
+#ifdef WIN32_MSC
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+#define NOMINMAX
+#ifdef STRICT
+#undef STRICT
+#endif
+#define NO_STRICT
+#endif // WIN32_MSC
+
 #endif /* ECELL4_CONFIG_H */


### PR DESCRIPTION
to avoid name collision between `ecell4::ReactionRule::STRICT` and a macro named `STRICT`. Also it prevents `min` and `max` macro expansions that sometimes cause a weird error.

It shall hopefully resolve most of the compilation errors on Windows (but not link error).