### PR TITLE
:green_heart: Fix build on appveyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg -O0 -Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
+if(WIN32)
+    add_definitions(-DNOMINMAX)
+    add_definitions(-DGSL_DLL)
+endif()
+
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_BINARY_DIR})
 enable_testing()

--- a/ecell4/core/Context.cpp
+++ b/ecell4/core/Context.cpp
@@ -1067,8 +1067,8 @@ _ReactionRuleExpressionMatcher::unit_group_type generate_units(
 
     // const ReactionRule::policy_type& policy(pttrn.policy());
 
-    if ((policy & ReactionRule::STRICT)
-        && !(policy & (ReactionRule::DESTROY | ReactionRule::IMPLICIT)))
+    if ((policy & ReactionRule::POLICY_STRICT)
+        && !(policy & (ReactionRule::POLICY_DESTROY | ReactionRule::POLICY_IMPLICIT)))
     {
         for (utils::get_mapper_mf<std::string, std::pair<std::string, unsigned int> >::type::const_iterator
             i(bondinfo.begin()); i != bondinfo.end(); ++i)
@@ -1119,7 +1119,7 @@ _ReactionRuleExpressionMatcher::unit_group_type generate_units(
 
     // 8. Resolve open bonds based on the policy
 
-    if (policy & ReactionRule::IMPLICIT)
+    if (policy & ReactionRule::POLICY_IMPLICIT)
     {
         for (std::vector<UnitSpecies>::iterator i(units.begin());
             i != units.end(); ++i)
@@ -1137,7 +1137,7 @@ _ReactionRuleExpressionMatcher::unit_group_type generate_units(
         }
     }
 
-    if (policy & ReactionRule::DESTROY)
+    if (policy & ReactionRule::POLICY_DESTROY)
     {
         for (utils::get_mapper_mf<std::string, std::pair<std::string, unsigned int> >::type::const_iterator
             i(bondinfo.begin()); i != bondinfo.end(); ++i)

--- a/ecell4/core/ReactionRule.cpp
+++ b/ecell4/core/ReactionRule.cpp
@@ -8,7 +8,7 @@ namespace ecell4
 {
 
 ReactionRule::ReactionRule()
-    : k_(0), reactants_(), products_(), policy_(STRICT)
+    : k_(0), reactants_(), products_(), policy_(POLICY_STRICT)
 {
     ;
 }
@@ -16,7 +16,7 @@ ReactionRule::ReactionRule()
 ReactionRule::ReactionRule(
     const reactant_container_type& reactants,
     const product_container_type& products)
-    : k_(0), reactants_(reactants), products_(products), policy_(STRICT)
+    : k_(0), reactants_(reactants), products_(products), policy_(POLICY_STRICT)
 {
     ;
 }
@@ -25,7 +25,7 @@ ReactionRule::ReactionRule(
     const reactant_container_type& reactants,
     const product_container_type& products,
     const Real& k)
-    : k_(k), reactants_(reactants), products_(products), policy_(STRICT)
+    : k_(k), reactants_(reactants), products_(products), policy_(POLICY_STRICT)
 {
     ;
 }
@@ -34,7 +34,7 @@ ReactionRule::ReactionRule(
     const reactant_container_type& reactants,
     const product_container_type& products,
     const Quantity<Real>& k)
-    : k_(k), reactants_(reactants), products_(products), policy_(STRICT)
+    : k_(k), reactants_(reactants), products_(products), policy_(POLICY_STRICT)
 {
     ;
 }

--- a/ecell4/core/ReactionRule.hpp
+++ b/ecell4/core/ReactionRule.hpp
@@ -32,9 +32,9 @@ public:
 
     enum policy_type
     {
-        STRICT = 1L << 0,
-        IMPLICIT = 1L << 1,
-        DESTROY = 1L << 2
+        POLICY_STRICT = 1L << 0,
+        POLICY_IMPLICIT = 1L << 1,
+        POLICY_DESTROY = 1L << 2
     };
 
 public:

--- a/ecell4/core/tests/ReactionRule_test.cpp
+++ b/ecell4/core/tests/ReactionRule_test.cpp
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE(ReactionRule_test_generate4)
     }
     {
         ReactionRule rr = create_degradation_reaction_rule(Species("B"), 1.0);
-        rr.set_policy(ReactionRule::IMPLICIT);
+        rr.set_policy(ReactionRule::POLICY_IMPLICIT);
 
         ReactionRule::reactant_container_type reactants(1, Species("A(b=u^1).B(b^1)"));
         std::vector<ReactionRule> ans;
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(ReactionRule_test_generate4)
     }
     {
         ReactionRule rr = create_degradation_reaction_rule(Species("B"), 1.0);
-        rr.set_policy(ReactionRule::DESTROY);
+        rr.set_policy(ReactionRule::POLICY_DESTROY);
 
         ReactionRule::reactant_container_type reactants(1, Species("A(b=u^1).B(b^1)"));
         std::vector<ReactionRule> ans;
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(ReactionRule_test_generate6)
 {
     {
         ReactionRule rr = create_degradation_reaction_rule(Species("A"), 1.0);
-        rr.set_policy(ReactionRule::IMPLICIT);
+        rr.set_policy(ReactionRule::POLICY_IMPLICIT);
         ReactionRule::reactant_container_type reactants(1, Species("A(b)"));
         std::vector<ReactionRule> ans;
         const ReactionRule _ans = format_reaction_rule_with_nosort(
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(ReactionRule_test_generate6)
     }
     {
         ReactionRule rr = create_degradation_reaction_rule(Species("A"), 1.0);
-        rr.set_policy(ReactionRule::IMPLICIT);
+        rr.set_policy(ReactionRule::POLICY_IMPLICIT);
         ReactionRule::reactant_container_type reactants(1, Species("A(b^1).B(b^1)"));
         std::vector<ReactionRule> ans;
         const ReactionRule _ans = format_reaction_rule_with_nosort(
@@ -441,7 +441,7 @@ BOOST_AUTO_TEST_CASE(ReactionRule_test_generate6)
     }
     {
         ReactionRule rr = create_degradation_reaction_rule(Species("A"), 1.0);
-        rr.set_policy(ReactionRule::IMPLICIT);
+        rr.set_policy(ReactionRule::POLICY_IMPLICIT);
         ReactionRule::reactant_container_type reactants(1, Species("A(b^1).A(b^1)"));
         std::vector<ReactionRule> ans;
         const ReactionRule _ans = format_reaction_rule_with_nosort(
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(ReactionRule_test_generate6)
     }
     {
         ReactionRule rr = create_degradation_reaction_rule(Species("A"), 1.0);
-        rr.set_policy(ReactionRule::DESTROY);
+        rr.set_policy(ReactionRule::POLICY_DESTROY);
         ReactionRule::reactant_container_type reactants(1, Species("A(b^1).A(b^1)"));
         std::vector<ReactionRule> ans;
         const ReactionRule _ans = format_reaction_rule_with_nosort(

--- a/ecell4/python_api/core.cpp
+++ b/ecell4/python_api/core.cpp
@@ -393,9 +393,9 @@ void define_reaction_rule(py::module& m)
         ));
 
     py::enum_<ReactionRule::policy_type>(m, "ReactionRulePolicy")
-        .value("STRICT", ReactionRule::policy_type::STRICT)
-        .value("IMPLICIT", ReactionRule::policy_type::IMPLICIT)
-        .value("DESTROY", ReactionRule::policy_type::DESTROY)
+        .value("STRICT", ReactionRule::policy_type::POLICY_STRICT)
+        .value("IMPLICIT", ReactionRule::policy_type::POLICY_IMPLICIT)
+        .value("DESTROY", ReactionRule::policy_type::POLICY_DESTROY)
         .export_values();
 
     m.def("create_degradation_reaction_rule", &create_degradation_reaction_rule);

--- a/ecell4/python_api/egfrd.cpp
+++ b/ecell4/python_api/egfrd.cpp
@@ -7,7 +7,7 @@
 #include "world_interface.hpp"
 
 namespace py = pybind11;
-using namespace ecell4::egfrd;
+// using namespace ecell4::egfrd;
 
 namespace ecell4
 {
@@ -18,6 +18,7 @@ namespace python_api
 static inline
 void define_bd_factory(py::module& m)
 {
+    using namespace ::ecell4::egfrd;
     using matrix_sizes_type = EGFRDWorld::matrix_sizes_type;
 
     py::class_<BDFactory> factory(m, "BDFactory");
@@ -33,6 +34,7 @@ void define_bd_factory(py::module& m)
 static inline
 void define_bd_simulator(py::module& m)
 {
+    using namespace ::ecell4::egfrd;
     using BDSimulator = egfrd::BDSimulator;
     using world_type = BDSimulator::world_type;
     using model_type = BDSimulator::model_type;
@@ -63,6 +65,7 @@ void define_bd_simulator(py::module& m)
 static inline
 void define_egfrd_factory(py::module& m)
 {
+    using namespace ::ecell4::egfrd;
     using matrix_sizes_type = EGFRDWorld::matrix_sizes_type;
 
     py::class_<EGFRDFactory> factory(m, "EGFRDFactory");
@@ -81,13 +84,14 @@ void define_egfrd_factory(py::module& m)
 static inline
 void define_egfrd_simulator(py::module& m)
 {
-    using EGFRDSimulator = egfrd::EGFRDSimulator;
-    using world_type = EGFRDSimulator::world_type;
-    using model_type = EGFRDSimulator::model_type;
-    using length_type = EGFRDSimulator::length_type;
+    using world_type = ::ecell4::egfrd::EGFRDSimulator::world_type;
+    using model_type = ::ecell4::egfrd::EGFRDSimulator::model_type;
+    using length_type = ::ecell4::egfrd::EGFRDSimulator::length_type;
 
-    py::class_<EGFRDSimulator, Simulator, PySimulator<EGFRDSimulator>,
-        boost::shared_ptr<EGFRDSimulator>> simulator(m, "EGFRDSimulator");
+    py::class_<::ecell4::egfrd::EGFRDSimulator, Simulator,
+               PySimulator<::ecell4::egfrd::EGFRDSimulator>,
+               boost::shared_ptr<::ecell4::egfrd::EGFRDSimulator>
+                   > simulator(m, "EGFRDSimulator");
     simulator
         .def(py::init<boost::shared_ptr<world_type>, Real, int, length_type>(),
                 py::arg("w"),
@@ -99,9 +103,9 @@ void define_egfrd_simulator(py::module& m)
                 py::arg("bd_dt_factor") = 1e-5,
                 py::arg("dissociation_retry_moves") = 1,
                 py::arg("user_max_shell_size") = std::numeric_limits<length_type>::infinity())
-        .def("last_reactions", &EGFRDSimulator::last_reactions)
-        .def("set_t", &EGFRDSimulator::set_t)
-        .def("set_paranoiac", &EGFRDSimulator::set_paranoiac);
+        .def("last_reactions", &::ecell4::egfrd::EGFRDSimulator::last_reactions)
+        .def("set_t", &::ecell4::egfrd::EGFRDSimulator::set_t)
+        .def("set_paranoiac", &::ecell4::egfrd::EGFRDSimulator::set_paranoiac);
     define_simulator_functions(simulator);
 
     m.attr("Simulator") = simulator;
@@ -110,6 +114,7 @@ void define_egfrd_simulator(py::module& m)
 static inline
 void define_egfrd_world(py::module& m)
 {
+    using namespace ::ecell4::egfrd;
     using position_type = EGFRDWorld::position_type;
     using matrix_sizes_type = EGFRDWorld::matrix_sizes_type;
     using particle_type = EGFRDWorld::particle_type;
@@ -167,6 +172,7 @@ void define_egfrd_world(py::module& m)
 static inline
 void define_reaction_info(py::module& m)
 {
+    using namespace ::ecell4::egfrd;
     using container_type = ReactionInfo::container_type;
 
     py::class_<ReactionInfo>(m, "ReactionInfo")


### PR DESCRIPTION
The following changes make it compiles on appveyor.

- Define some macros through `CMakeLists.txt`
  - `NOMINMAX`
    - to prevent macro definition in `<windows.h>`.
  - `GSL_DLL`
    - required to link GNU Scientific Library on Windows.
- Rename (add prefix `POLICY_`) enumerators in `ReactionRule::policy_type`
  - to avoid name conflict with predefined macro, `STRICT`.
- Remove `using namespace ecell4::egfrd` from `python_api/egfrd.cpp`
  - the reason is a bit complicated. please see the commit message.
- Update `greens_functions`
  - almost the same reason as above.