### PR TITLE
Add macOS arm64 wheel build guide and ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ CMakeFiles
 *.so
 ecell4/*/tests/*.h5
 ecell4/*/tests/*_test
+dist/
+ecell4_base.egg-info/

--- a/README.md
+++ b/README.md
@@ -14,3 +14,32 @@ What is E-Cell System?
 E-Cell System is a software platform for modeling, simulation and analysis of complex, heterogeneous and multi-scale systems like a cell.
 
 See https://ecell4.e-cell.org/
+
+Build macOS arm64 wheel
+------------------------
+
+The following steps will build:
+`dist/ecell4_base-2.1.2-cp310-cp310-macosx_26_0_arm64.whl`
+on macOS Tahoe (Apple Silicon, arm64).
+
+```bash
+# 1) Install required build dependencies
+brew install cmake hdf5 boost gsl
+
+# 2) Build wheel for arm64
+cd /path/to/ecell4_base
+rm -rf dist build
+uv venv --python 3.10
+# or
+# uv venv --python 3.11
+# uv venv --python 3.12
+# uv venv --python 3.13
+# uv venv --python 3.14
+source .venv/bin/activate
+uv pip install pip
+CMAKE_OSX_ARCHITECTURES=arm64 pip wheel . -w dist --no-deps
+
+# 3) (Optional) Verify install from the built wheel in the above venv
+pip install dist/ecell4_base-2.1.2-cp310-cp310-macosx_26_0_arm64.whl
+python -c "from ecell4_base.core import *; sp1 = Species('A', 0.0025, 1); print(sp1.list_attributes())"
+```


### PR DESCRIPTION
Document steps in README for building a macOS arm64 wheel for ecell4_base (brew deps, virtualenv, pip wheel command and verification). Also update .gitignore to ignore dist/ and ecell4_base.egg-info/ generated by the build.